### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libspinner
 
-libspinner is a C library that provides terminal spinners and progress indicators to display in the terminal. This is a port of the Go library [here](github.com/briandowns/spinner).
+libspinner is a C library that provides terminal spinners and progress indicators to display in the terminal. This is a port of the Go library [here](https://github.com/briandowns/spinner).
 
 *NOTE*: Be sure to call `spinner_stop(s)` in any signal handlers so the underlying pthread doesn't leak.
 


### PR DESCRIPTION
Seems like GH wasn't into not having https:// at the beginning of link to spinner.